### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/kareha.js
+++ b/kareha.js
@@ -60,7 +60,7 @@ function delete_post(thread,post,file)
 		document.location=script
 		+"?task=delete"
 		+"&delete="+thread+","+post
-		+"&password="+password
+		+"&password="+encodeURIComponent(password)
 		+"&fileonly="+(fileonly?"1":"0");
 	}
 }


### PR DESCRIPTION
Potential fix for [https://github.com/catharsis71/kareha/security/code-scanning/1](https://github.com/catharsis71/kareha/security/code-scanning/1)

To fix the problem, we need to ensure that the user input (`password`) is properly encoded before being used in the URL. This can be achieved by using `encodeURIComponent` to encode the `password` value, which will escape any special characters and prevent them from being interpreted as HTML or script.

- Locate the line where the `password` value is concatenated into the URL string.
- Use `encodeURIComponent` to encode the `password` value before concatenating it into the URL string.
- Ensure that the rest of the functionality remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
